### PR TITLE
Attempt to fix font not loading when deploy to gh-pages

### DIFF
--- a/feeding-game/GruntFile.js
+++ b/feeding-game/GruntFile.js
@@ -9,7 +9,7 @@ module.exports = function (grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     clean: [
-      'deploy'
+      './deploy'
     ],
     connect: {
       server: {

--- a/feeding-game/src/index.html
+++ b/feeding-game/src/index.html
@@ -21,7 +21,7 @@
   <style type="text/css">
     @font-face {
       font-family: 'PressStart2P';
-      src: url('../assets/fonts/PressStart2P.ttf') format('truetype');
+      src: url('./assets/fonts/PressStart2P.ttf') format('truetype');
     }
 
     #font-load-hack {


### PR DESCRIPTION
This also includes a small modification to the `GruntFile.js` to fix a grunt-clean problem I was running into on a Windows machine. I'm gonna try out this branch on a mac setup too before merging just to make sure I'm not breaking things there.
